### PR TITLE
Ignition 7.9 Boolean write fix

### DIFF
--- a/eWonConnector-gateway/src/main/java/org/imdc/ewon/SyncManager.java
+++ b/eWonConnector-gateway/src/main/java/org/imdc/ewon/SyncManager.java
@@ -351,8 +351,12 @@ public class SyncManager {
                            String tagName =
                                  replaceUnderscore ? unSanitizeName(tagPath.getItemName())
                                        : tagPath.getItemName();
+                           String writeValue = o.toString();
+                           if (o instanceof Boolean) {
+                              writeValue = (Boolean) o ? "1" : "0";
+                           }
                            comm.writeTag(tagPath.getParentPath().getItemName(), tagName,
-                                 o.toString());
+                                 writeValue);
                            provider.updateValue(p.toStringPartial(), o, TagQuality.GOOD);
                         } catch (Exception e) {
                            logger.error("Writing tag to eWON via Talk2M API Failed");


### PR DESCRIPTION
Ignition uses string value "true"/"false" for Boolean tags, thus we must convert to "1"/"0" for use with M2Web API

fixes #21 