### PR TITLE
#59 Fix NullPointerException at startup with a fresh install

### DIFF
--- a/eWonConnector-gateway/src/main/java/org/imdc/ewon/config/EwonConnectorSettings.java
+++ b/eWonConnector-gateway/src/main/java/org/imdc/ewon/config/EwonConnectorSettings.java
@@ -248,8 +248,17 @@ public class EwonConnectorSettings extends PersistentRecord {
     * @return created AuthInfo object
     */
    public AuthInfo getAuthInfo() {
-      return new AuthInfo(getAccount(), getUserName(), getPassword(), getAPIKey(),
-            getEwonUserName(), getEwonPassword());
+      AuthInfo authInfo;
+      try {
+         // Try fetching the credentials from the configuration page
+         authInfo = new AuthInfo(getAccount(), getUserName(), getPassword(), getAPIKey(),
+                 getEwonUserName(), getEwonPassword());
+      } catch (NullPointerException e) {
+         // Some of the configuration page credentials are empty, force empty strings
+         // Ignition logs will indicate incorrect user credentials
+         authInfo = new AuthInfo("", "", "", "", "", "");
+      }
+      return authInfo;
    }
 
    /**


### PR DESCRIPTION
Apply the fix from Ignition 8 module (4134692b87613a9ce7a8031e4eba5d70b973bb49) that prevents a NullPointerException at startup on a fresh install of the connector.

fixes #59 