### PR TITLE
Ignition 8 error historical reminder msg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Ewon Ignition 8 Connector Changelog
 
+## v1.1.11
+
+### Major Changes
+
+* Fixed an issue that caused realtime update errors on tags with underscores
+
 ## v.1.1.10
 
 ### Major Changes

--- a/eWonConnector-build/pom.xml
+++ b/eWonConnector-build/pom.xml
@@ -47,7 +47,7 @@
                     <moduleId>com.hms_networks.EwonConnector</moduleId>
                     <moduleName>${project.parent.name}</moduleName>
                     <moduleDescription>${project.description}</moduleDescription>
-                    <moduleVersion>1.1.10</moduleVersion>
+                    <moduleVersion>1.1.11</moduleVersion>
                     <requiredIgnitionVersion>8.0.0</requiredIgnitionVersion>
                     <requiredFrameworkVersion>8</requiredFrameworkVersion>
                     <licenseFile>license.html</licenseFile>

--- a/eWonConnector-gateway/src/main/java/com/hms_networks/SyncManager.java
+++ b/eWonConnector-gateway/src/main/java/com/hms_networks/SyncManager.java
@@ -475,7 +475,7 @@ public class SyncManager {
                 // For each realtime tag on current Ewon, update value
                 for (String tag : liveEwonNames.get(eWonName)) {
                     Object value;
-                    String valueString = tagData.getTagValue(unSanitizeName(tag));
+                    String valueString = tagData.getTagValue(replaceUnderscore ? unSanitizeName(tag): tag);
 
                     // Identify tag type and store properly
                     try {


### PR DESCRIPTION
Fixed an issue that caused tag names to be unsanitized when sanitization disabled.

Added additional logging detail to realtime update error message.